### PR TITLE
refactor/fix: update MCIR naming rule/validation, update AWS's user account, use private ip for haproxy, fix connection error over 10 VMs 

### DIFF
--- a/src/core/model/node.go
+++ b/src/core/model/node.go
@@ -34,7 +34,6 @@ func NewNodeVM(namespace string, clusterName string, vm VM) *Node {
 		Model:       Model{Kind: KIND_NODE, Name: vm.Name},
 		Credential:  vm.Credential,
 		PublicIP:    vm.PublicIP,
-		UId:         vm.UId,
 		Role:        vm.Role,
 		Spec:        vm.Spec,
 		Csp:         vm.Csp,

--- a/src/core/model/tumblebug/spec.go
+++ b/src/core/model/tumblebug/spec.go
@@ -14,7 +14,6 @@ type Spec struct {
 	Model
 	Config      string `json:"connectionName"`
 	CspSpecName string `json:"cspSpecName"`
-	Role        string `json:"role"`
 }
 
 func NewSpec(ns string, name string, conf string) *Spec {

--- a/src/core/model/vm.go
+++ b/src/core/model/vm.go
@@ -24,12 +24,20 @@ type VM struct {
 	UserAccount  string     `json:"vmUserAccount"`
 	UserPassword string     `json:"vmUserPassword"`
 	Description  string     `json:"description"`
-	PublicIP     string     `json:"publicIP"` // output
+	PublicIP     string     `json:"publicIP"`  // output
+	PrivateIP    string     `json:"privateIP"` // output
 	Credential   string     // private
-	UId          string     `json:"uid"`
 	Role         string     `json:"role"`
 	Csp          config.CSP `json:"csp"`
 	IsCPLeader   bool       `json:"isCPLeader"`
+}
+
+type VMInfo struct {
+	Name       string     `json:"name"`
+	Credential string     // private
+	Role       string     `json:"role"`
+	Csp        config.CSP `json:"csp"`
+	IsCPLeader bool       `json:"isCPLeader"`
 }
 
 const (
@@ -68,6 +76,7 @@ func (self *VM) CopyScripts(sshInfo *ssh.SSHInfo, networkCni string) error {
 			return errors.New(fmt.Sprintf("copy scripts error (server=%s, cause=%s)", sshInfo.ServerPort, err))
 		}
 	}
+	logger.Infof("end script file copy (vm=%s, server=%s)\n", self.Name, sshInfo.ServerPort)
 	return nil
 }
 

--- a/src/core/service/cluster.go
+++ b/src/core/service/cluster.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/cloud-barista/cb-ladybug/src/core/model"
 	"github.com/cloud-barista/cb-ladybug/src/core/model/tumblebug"
@@ -80,35 +81,36 @@ func CreateCluster(namespace string, req *model.ClusterReq) (*model.Cluster, err
 	cIdx := 0
 	wIdx := 0
 	var nodes []model.Node
+	var vmInfos []model.VMInfo
 
 	for _, nodeConfigInfo := range nodeConfigInfos {
 		// MCIR - 존재하면 재활용 없다면 생성 기준
 		// 1. create vpc
-		vpc, err := nodeConfigInfo.CreateVPC(namespace, clusterName)
+		vpc, err := nodeConfigInfo.CreateVPC(namespace)
 		if err != nil {
 			return nil, err
 		}
 
 		// 2. create firewall
-		fw, err := nodeConfigInfo.CreateFirewall(namespace, clusterName)
+		fw, err := nodeConfigInfo.CreateFirewall(namespace)
 		if err != nil {
 			return nil, err
 		}
 
 		// 3. create sshKey
-		sshKey, err := nodeConfigInfo.CreateSshKey(namespace, clusterName)
+		sshKey, err := nodeConfigInfo.CreateSshKey(namespace)
 		if err != nil {
 			return nil, err
 		}
 
 		// 4. create image
-		image, err := nodeConfigInfo.CreateImage(namespace, clusterName)
+		image, err := nodeConfigInfo.CreateImage(namespace)
 		if err != nil {
 			return nil, err
 		}
 
 		// 5. create spec
-		spec, err := nodeConfigInfo.CreateSpec(namespace, clusterName)
+		spec, err := nodeConfigInfo.CreateSpec(namespace)
 		if err != nil {
 			return nil, err
 		}
@@ -132,22 +134,27 @@ func CreateCluster(namespace string, req *model.ClusterReq) (*model.Cluster, err
 				UserAccount:  nodeConfigInfo.Account,
 				UserPassword: "",
 				Description:  "",
-				Credential:   sshKey.PrivateKey,
-				Role:         nodeConfigInfo.Role,
-				Csp:          nodeConfigInfo.Csp,
+			}
+
+			vmInfo := model.VMInfo{
+				Credential: sshKey.PrivateKey,
+				Role:       nodeConfigInfo.Role,
+				Csp:        nodeConfigInfo.Csp,
 			}
 
 			if nodeConfigInfo.Role == config.CONTROL_PLANE {
 				vm.Name = lang.GetNodeName(clusterName, config.CONTROL_PLANE, cIdx)
 				if cIdx == 1 {
-					vm.IsCPLeader = true
+					vmInfo.IsCPLeader = true
 					cluster.CpLeader = vm.Name
 				}
 			} else {
 				vm.Name = lang.GetNodeName(clusterName, config.WORKER, wIdx)
 			}
+			vmInfo.Name = vm.Name
 
 			mcis.VMs = append(mcis.VMs, vm)
+			vmInfos = append(vmInfos, vmInfo)
 		}
 	}
 
@@ -158,9 +165,22 @@ func CreateCluster(namespace string, req *model.ClusterReq) (*model.Cluster, err
 	}
 	logger.Infof("create MCIS OK.. (name=%s)", mcisName)
 
+	cpMcis := tumblebug.MCIS{}
 	// 결과값 저장
 	cluster.MCIS = mcisName
 	for _, vm := range mcis.VMs {
+		for _, vmInfo := range vmInfos {
+			if vm.Name == vmInfo.Name {
+				vm.Credential = vmInfo.Credential
+				vm.Role = vmInfo.Role
+				vm.Csp = vmInfo.Csp
+				vm.IsCPLeader = vmInfo.IsCPLeader
+
+				cpMcis.VMs = append(cpMcis.VMs, vm)
+				break
+			}
+		}
+
 		node := model.NewNodeVM(namespace, cluster.Name, vm)
 		node.UId = lang.GetUid()
 
@@ -179,16 +199,19 @@ func CreateCluster(namespace string, req *model.ClusterReq) (*model.Cluster, err
 
 	var wg sync.WaitGroup
 	c := make(chan error)
-	wg.Add(len(mcis.VMs))
+	wg.Add(len(cpMcis.VMs))
 
 	// bootstrap
 	logger.Infoln("start k8s bootstrap")
-	for _, vm := range mcis.VMs {
-		err = cluster.Update()
-		if err != nil {
-			return nil, err
-		}
 
+	time.Sleep(2 * time.Second)
+
+	err = cluster.Update()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, vm := range cpMcis.VMs {
 		go func(vm model.VM) {
 			defer wg.Done()
 			sshInfo := ssh.SSHInfo{
@@ -196,7 +219,12 @@ func CreateCluster(namespace string, req *model.ClusterReq) (*model.Cluster, err
 				PrivateKey: []byte(vm.Credential),
 				ServerPort: fmt.Sprintf("%s:22", vm.PublicIP),
 			}
-			_ = vm.ConnectionTest(&sshInfo)
+			err = vm.ConnectionTest(&sshInfo)
+			// retry
+			if err != nil {
+				vm.ConnectionTest(&sshInfo)
+			}
+
 			err := vm.CopyScripts(&sshInfo, cluster.NetworkCni)
 			if err != nil {
 				cluster.Fail()
@@ -231,10 +259,10 @@ func CreateCluster(namespace string, req *model.ClusterReq) (*model.Cluster, err
 
 	// init & join
 	var joinCmd []string
-	IPs := GetControlPlaneIPs(mcis.VMs)
+	IPs := GetControlPlaneIPs(cpMcis.VMs)
 
 	logger.Infoln("start k8s init")
-	for _, vm := range mcis.VMs {
+	for _, vm := range cpMcis.VMs {
 		if vm.Role == config.CONTROL_PLANE && vm.IsCPLeader {
 			sshInfo := ssh.SSHInfo{
 				UserName:   GetUserAccount(vm.Csp),
@@ -242,7 +270,7 @@ func CreateCluster(namespace string, req *model.ClusterReq) (*model.Cluster, err
 				ServerPort: fmt.Sprintf("%s:22", vm.PublicIP),
 			}
 
-			logger.Infoln("install HAProxy")
+			logger.Infof("install HAProxy (vm=%s)", vm.Name)
 			err := vm.InstallHAProxy(&sshInfo, IPs)
 			if err != nil {
 				cluster.Fail()
@@ -269,24 +297,30 @@ func CreateCluster(namespace string, req *model.ClusterReq) (*model.Cluster, err
 	logger.Infoln("end k8s init")
 
 	logger.Infoln("start k8s join")
-	for _, vm := range mcis.VMs {
-		sshInfo := ssh.SSHInfo{
-			UserName:   GetUserAccount(vm.Csp),
-			PrivateKey: []byte(vm.Credential),
-			ServerPort: fmt.Sprintf("%s:22", vm.PublicIP),
-		}
-
-		if vm.Role == config.CONTROL_PLANE {
-			if !vm.IsCPLeader {
-				logger.Infoln("control plane join")
-				err := vm.ControlPlaneJoin(&sshInfo, &joinCmd[0])
-				if err != nil {
-					cluster.Fail()
-					return nil, err
-				}
+	for _, vm := range cpMcis.VMs {
+		if vm.Role == config.CONTROL_PLANE && !vm.IsCPLeader {
+			sshInfo := ssh.SSHInfo{
+				UserName:   GetUserAccount(vm.Csp),
+				PrivateKey: []byte(vm.Credential),
+				ServerPort: fmt.Sprintf("%s:22", vm.PublicIP),
 			}
-		} else {
-			logger.Infoln("worker join")
+			logger.Infof("control plane join (vm=%s)", vm.Name)
+			err := vm.ControlPlaneJoin(&sshInfo, &joinCmd[0])
+			if err != nil {
+				cluster.Fail()
+				return nil, err
+			}
+		}
+	}
+
+	for _, vm := range cpMcis.VMs {
+		if vm.Role == config.WORKER {
+			sshInfo := ssh.SSHInfo{
+				UserName:   GetUserAccount(vm.Csp),
+				PrivateKey: []byte(vm.Credential),
+				ServerPort: fmt.Sprintf("%s:22", vm.PublicIP),
+			}
+			logger.Infof("worker join (vm=%s)", vm.Name)
 			err := vm.WorkerJoin(&sshInfo, &joinCmd[1])
 			if err != nil {
 				cluster.Fail()

--- a/src/core/service/common.go
+++ b/src/core/service/common.go
@@ -63,7 +63,7 @@ func GetControlPlaneIPs(VMs []model.VM) []string {
 	var IPs []string
 	for _, vm := range VMs {
 		if vm.Role == config.CONTROL_PLANE {
-			IPs = append(IPs, vm.PublicIP)
+			IPs = append(IPs, vm.PrivateIP)
 		}
 	}
 	return IPs

--- a/src/core/service/csp.go
+++ b/src/core/service/csp.go
@@ -38,13 +38,8 @@ var imageMap = map[string]string{
 	"sa-east-1":      "ami-0fd2c3d373788b726", //남아메리카 (상파울루)
 }
 
-// TODO [update/hard-coding] host user account
+// get vm user account
 func GetUserAccount(csp config.CSP) string {
-
-	if csp == config.CSP_AWS {
-		return "ubuntu"
-	}
-
 	return "cb-user"
 }
 

--- a/src/core/service/node.go
+++ b/src/core/service/node.go
@@ -73,31 +73,31 @@ func AddNode(namespace string, clusterName string, req *model.NodeReq) (*model.N
 	for _, nodeConfigInfo := range nodeConfigInfos {
 		// MCIR - 존재하면 재활용 없다면 생성 기준
 		// 1. create vpc
-		vpc, err := nodeConfigInfo.CreateVPC(namespace, clusterName)
+		vpc, err := nodeConfigInfo.CreateVPC(namespace)
 		if err != nil {
 			return nil, err
 		}
 
 		// 2. create firewall
-		fw, err := nodeConfigInfo.CreateFirewall(namespace, clusterName)
+		fw, err := nodeConfigInfo.CreateFirewall(namespace)
 		if err != nil {
 			return nil, err
 		}
 
 		// 3. create sshKey
-		sshKey, err := nodeConfigInfo.CreateSshKey(namespace, clusterName)
+		sshKey, err := nodeConfigInfo.CreateSshKey(namespace)
 		if err != nil {
 			return nil, err
 		}
 
 		// 4. create image
-		image, err := nodeConfigInfo.CreateImage(namespace, clusterName)
+		image, err := nodeConfigInfo.CreateImage(namespace)
 		if err != nil {
 			return nil, err
 		}
 
 		// 5. create spec
-		spec, err := nodeConfigInfo.CreateSpec(namespace, clusterName)
+		spec, err := nodeConfigInfo.CreateSpec(namespace)
 		if err != nil {
 			return nil, err
 		}
@@ -122,7 +122,7 @@ func AddNode(namespace string, clusterName string, req *model.NodeReq) (*model.N
 				UserPassword: "",
 				Description:  "",
 				Credential:   sshKey.PrivateKey,
-				Role:         spec.Role,
+				Role:         nodeConfigInfo.Role,
 				Csp:          nodeConfigInfo.Csp,
 			}
 
@@ -165,19 +165,19 @@ func AddNode(namespace string, clusterName string, req *model.NodeReq) (*model.N
 				c <- err
 			}
 
-			logger.Infoln("set systemd service")
+			logger.Infof("set systemd service (vm=%s)", vm.Name)
 			err = vm.SetSystemd(&sshInfo, networkCni)
 			if err != nil {
 				c <- err
 			}
 
-			logger.Infoln("bootstrap")
+			logger.Infof("bootstrap (vm=%s)", vm.Name)
 			err = vm.Bootstrap(&sshInfo)
 			if err != nil {
 				c <- err
 			}
 
-			logger.Infoln("join")
+			logger.Infof("join (vm=%s)", vm.Name)
 			err = vm.WorkerJoin(&sshInfo, &workerJoinCmd)
 			if err != nil {
 				c <- err
@@ -202,6 +202,7 @@ func AddNode(namespace string, clusterName string, req *model.NodeReq) (*model.N
 	nodes := model.NewNodeList(namespace, clusterName)
 	for _, vm := range TVMs {
 		node := model.NewNodeVM(namespace, clusterName, vm.VM)
+		node.UId = lang.GetUid()
 		err := node.Insert()
 		if err != nil {
 			return nil, err
@@ -235,7 +236,7 @@ func RemoveNode(namespace string, clusterName string, nodeName string) (*model.S
 		PrivateKey: []byte(cpNode.Credential),
 		ServerPort: fmt.Sprintf("%s:22", cpNode.PublicIP),
 	}
-	cmd := fmt.Sprintf("sudo kubectl drain %s --kubeconfig=/etc/kubernetes/admin.conf --ignore-daemonsets", hostName)
+	cmd := fmt.Sprintf("sudo kubectl drain %s --kubeconfig=/etc/kubernetes/admin.conf --ignore-daemonsets --force --delete-local-data", hostName)
 	result, err := ssh.SSHRun(sshInfo, cmd)
 	if err != nil {
 		status.Message = "kubectl drain failed"

--- a/src/utils/app/ack.go
+++ b/src/utils/app/ack.go
@@ -49,21 +49,47 @@ func ClusterReqValidate(req model.ClusterReq) error {
 	if len(req.ControlPlane) == 0 {
 		return errors.New("control plane node must be at least one")
 	}
+	if len(req.ControlPlane) > 1 {
+		return errors.New("only one control plane node is supported")
+	}
 	if len(req.Worker) == 0 {
 		return errors.New("worker node must be at least one")
 	}
 	if !(req.Config.Kubernetes.NetworkCni == config.NETWORKCNI_CANAL || req.Config.Kubernetes.NetworkCni == config.NETWORKCNI_KILO) {
-		return errors.New("network cni allows only Kilo or Canal")
+		return errors.New("network cni allows only kilo or canal")
 	}
+
+	if len(req.Name) == 0 {
+		return errors.New("cluster name is empty")
+	} else {
+		err := lang.CheckName(req.Name)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(req.Config.Kubernetes.PodCidr) > 0 {
+		err := lang.CheckIpCidr("podCidr", req.Config.Kubernetes.PodCidr)
+		if err != nil {
+			return err
+		}
+	}
+	if len(req.Config.Kubernetes.ServiceCidr) > 0 {
+		err := lang.CheckIpCidr("serviceCidr", req.Config.Kubernetes.ServiceCidr)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
 func NodeReqValidate(req model.NodeReq) error {
 	if len(req.ControlPlane) > 0 {
-		return errors.New("control plane node not supported")
+		return errors.New("control plane node is not supported")
 	}
 	if len(req.Worker) == 0 {
-		return errors.New("worker node count must be at least one")
+		return errors.New("worker node must be at least one")
 	}
 
 	return nil

--- a/src/utils/lang/functions.go
+++ b/src/utils/lang/functions.go
@@ -1,8 +1,10 @@
 package lang
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -91,4 +93,24 @@ func GetMaxNumber(arr []int) int {
 		}
 	}
 	return max
+}
+
+func CheckName(name string) error {
+	reg, _ := regexp.Compile("[a-z]([-a-z0-9]*[a-z0-9])?")
+	filtered := reg.FindString(name)
+
+	if filtered != name {
+		return errors.New(name + ": The first character of name must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.")
+	}
+	return nil
+}
+
+func CheckIpCidr(name string, val string) error {
+	reg, _ := regexp.Compile("^((?:\\d{1,3}.){3}\\d{1,3})\\/(\\d{1,2})$")
+	filtered := reg.FindString(val)
+
+	if filtered != val {
+		return errors.New(fmt.Sprintf("%s %s : Type mismatch ex)10.244.0.0/16", name, val))
+	}
+	return nil
 }


### PR DESCRIPTION
- mcir name 변경
- validation check 개선
- drain node 옵션 추가
- csp useraccount 변경
- haproxy 구성시 privateip로 변경
- vm 10개 이상일 때 connection error 수정