### PR TITLE
Remove return code from getHostName

### DIFF
--- a/src/core/service/node.go
+++ b/src/core/service/node.go
@@ -356,10 +356,6 @@ func getHostName(namespace string, clusterName string, nodeName string) (string,
 		}
 	}
 
-	if dNode.Csp == config.CSP_GCP || dNode.Csp == config.CSP_AZURE {
-		return nodeName, nil
-	}
-
 	userAccount := GetUserAccount(dNode.Csp)
 	sshInfo := ssh.SSHInfo{
 		UserName:   userAccount,


### PR DESCRIPTION
mcis 생성 시 vm id가 변경되어 클러스터의 노드명도 변경됨에 따라, 노드 삭제 시 hostname 조회하는 부분을 모든 csp에 적용시킴