### PR TITLE
Add terminate, refine to delete cluster

### DIFF
--- a/src/core/model/tumblebug/mcis.go
+++ b/src/core/model/tumblebug/mcis.go
@@ -63,3 +63,19 @@ func (self *MCIS) DELETE() error {
 
 	return nil
 }
+
+func (self *MCIS) TERMINATE() error {
+	_, err := self.execute(http.MethodGet, fmt.Sprintf("/ns/%s/mcis/%s?action=terminate", self.namespace, self.Name), nil, model.Status{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (self *MCIS) REFINE() error {
+	_, err := self.execute(http.MethodGet, fmt.Sprintf("/ns/%s/mcis/%s?action=refine", self.namespace, self.Name), nil, model.Status{})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/core/service/cluster.go
+++ b/src/core/service/cluster.go
@@ -345,6 +345,7 @@ func DeleteCluster(namespace string, clusterName string) (*model.Status, error) 
 
 	logger.Infof("start delete Cluster (name=%s)", mcisName)
 	mcis := tumblebug.NewMCIS(namespace, mcisName)
+	cluster := model.NewCluster(namespace, clusterName)
 	exist, err := mcis.GET()
 	if err != nil {
 		return status, err
@@ -377,18 +378,22 @@ func DeleteCluster(namespace string, clusterName string) (*model.Status, error) 
 		}
 
 		logger.Infof("delete MCIS OK.. (name=%s)", mcisName)
-		status.Code = model.STATUS_SUCCESS
 		status.Message = fmt.Sprintf("cluster %s has been deleted", mcisName)
 
-		cluster := model.NewCluster(namespace, clusterName)
 		if err := cluster.Delete(); err != nil {
 			status.Message = fmt.Sprintf("cluster %s has been deleted but cannot delete from the store", mcisName)
 			return status, nil
 		}
 	} else {
-		status.Code = model.STATUS_NOT_EXIST
 		logger.Infof("delete Cluster skip (MCIS cannot find).. (name=%s)", mcisName)
+		status.Message = fmt.Sprintf("cluster %s not found", mcisName)
+
+		if err := cluster.Delete(); err != nil {
+			status.Message = fmt.Sprintf("cluster %s not found and cannot delete from the store", mcisName)
+			return status, nil
+		}
 	}
 
+	status.Code = model.STATUS_SUCCESS
 	return status, nil
 }

--- a/src/core/service/cluster.go
+++ b/src/core/service/cluster.go
@@ -3,6 +3,7 @@ package service
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -337,35 +338,56 @@ func CreateCluster(namespace string, req *model.ClusterReq) (*model.Cluster, err
 }
 
 func DeleteCluster(namespace string, clusterName string) (*model.Status, error) {
-	mcisName := clusterName //cluster 이름과 동일하게 (임시)
+	mcisName := clusterName
 
 	status := model.NewStatus()
 	status.Code = model.STATUS_UNKNOWN
 
-	// 1. delete mcis
-	logger.Infof("start delete MCIS (name=%s)", mcisName)
+	logger.Infof("start delete Cluster (name=%s)", mcisName)
 	mcis := tumblebug.NewMCIS(namespace, mcisName)
 	exist, err := mcis.GET()
 	if err != nil {
 		return status, err
 	}
 	if exist {
-		if err = mcis.DELETE(); err != nil {
+		logger.Infof("terminate MCIS (name=%s)", mcisName)
+		if err = mcis.TERMINATE(); err != nil {
+			logger.Errorf("terminate mcis error : %v", err)
 			return status, err
 		}
-		// sleep 이후 확인하는 로직 추가 필요
+		time.Sleep(5 * time.Second)
+
+		logger.Infof("delete MCIS (name=%s)", mcisName)
+		if err = mcis.DELETE(); err != nil {
+			if strings.Contains(err.Error(), "Deletion is not allowed") {
+				logger.Infof("refine mcis (name=%s)", mcisName)
+				if err = mcis.REFINE(); err != nil {
+					logger.Errorf("refine MCIS error : %v", err)
+					return status, err
+				}
+				logger.Infof("delete MCIS (name=%s)", mcisName)
+				if err = mcis.DELETE(); err != nil {
+					logger.Errorf("delete MCIS error : %v", err)
+					return status, err
+				}
+			} else {
+				logger.Errorf("delete MCIS error : %v", err)
+				return status, err
+			}
+		}
+
 		logger.Infof("delete MCIS OK.. (name=%s)", mcisName)
 		status.Code = model.STATUS_SUCCESS
-		status.Message = "success"
+		status.Message = fmt.Sprintf("cluster %s has been deleted", mcisName)
 
 		cluster := model.NewCluster(namespace, clusterName)
 		if err := cluster.Delete(); err != nil {
-			status.Message = "delete success but cannot delete from the store"
+			status.Message = fmt.Sprintf("cluster %s has been deleted but cannot delete from the store", mcisName)
 			return status, nil
 		}
 	} else {
 		status.Code = model.STATUS_NOT_EXIST
-		logger.Infof("delete MCIS skip (cannot find).. (name=%s)", mcisName)
+		logger.Infof("delete Cluster skip (MCIS cannot find).. (name=%s)", mcisName)
 	}
 
 	return status, nil


### PR DESCRIPTION
- 클러스터 삭제 시, mcis terminate 실행 후 mcis delete 실행 (mcis delete 실패 시, mcis refine 후 다시 mcis delete)
- 삭제하려는 mcis가 존재하지 않을 때 해당 cluster의 meta-data 삭제