### PR TITLE
Improve conn-config-env-var-names

### DIFF
--- a/docs/test/README.md
+++ b/docs/test/README.md
@@ -36,20 +36,20 @@ $ docker run -d -p 1323:1323 --name cb-tumblebug --link cb-spider:cb-spider clou
 * 환경변수 : 클라우드별 연결정보
 
 ```
-$ export PROJECT="<project name>"
-$ export PKEY="<private key>"
-$ export SA="<service account email>"
+$ export GCP_PROJECT="<project name>"
+$ export GCP_PKEY="<private key>"
+$ export GCP_SA="<service account email>"
 ```
 
-* 환경변수 : REGION, ZONE
+* 환경변수 : GCP_REGION, GCP_ZONE
 
 ```
-$ export REGION="<region name>" 
-$ export ZONE="<zone name>"
+$ export GCP_REGION="<region name>" 
+$ export GCP_ZONE="<zone name>"
 
 # 예 : asia-northeast3 (서울리전)
-$ export REGION="asia-northeast3" 
-$ export ZONE="asia-northeast3-a"
+$ export GCP_REGION="asia-northeast3" 
+$ export GCP_ZONE="asia-northeast3-a"
 ```
 
 * Cloud Connection Info. 등록
@@ -63,23 +63,23 @@ $ ./connectioninfo-create.sh GCP
 * 환경변수 : 클라우드별 연결정보
 
 ```
-$ export KEY="<aws_access_key_id>"
-$ export SECRET="<aws_secret_access_key>"
+$ export AWS_KEY="<aws_access_key_id>"
+$ export AWS_SECRET="<aws_secret_access_key>"
 ```
 
-* 환경변수 : REGION, ZONE
+* 환경변수 : AWS_REGION, AWS_ZONE
 
 ```
-$ export REGION="<region name>" 
-$ export ZONE="<zone name>"
+$ export AWS_REGION="<region name>" 
+$ export AWS_ZONE="<zone name>"
 
 # 예: ap-northeast-2 (서울리전)
-$ export REGION="ap-northeast-2"
-$ export ZONE="ap-northeast-2a"
+$ export AWS_REGION="ap-northeast-2"
+$ export AWS_ZONE="ap-northeast-2a"
 
 # 예: ap-northeast-1 (일본리전)
-$ export REGION="ap-northeast-1"
-$ export ZONE="ap-northeast-1a"
+$ export AWS_REGION="ap-northeast-1"
+$ export AWS_ZONE="ap-northeast-1a"
 ```
 
 * Cloud Connection Info. 등록
@@ -93,21 +93,21 @@ $ ./connectioninfo-create.sh AWS
 * 환경변수 : 클라우드별 연결정보
 
 ```
-$ export CLIENT_ID="<azure_client_id>"
-$ export CLIENT_SECRET="<azure_client_secret>"
-$ export TENANT_ID="<azure_tenant_id>"
-$ export SUBSCRIPTION_ID="<azure_subscription_id>"
+$ export AZURE_CLIENT_ID="<azure_client_id>"
+$ export AZURE_CLIENT_SECRET="<azure_client_secret>"
+$ export AZURE_TENANT_ID="<azure_tenant_id>"
+$ export AZURE_SUBSCRIPTION_ID="<azure_subscription_id>"
 ```
 
-* 환경변수 : REGION, RESOURCE_GROUP
+* 환경변수 : AZURE_REGION, AZURE_RESOURCE_GROUP
 
 ```
-$ export REGION="<region name>" 
-$ export RESOURCE_GROUP="<resource group>"
+$ export AZURE_REGION="<region name>" 
+$ export AZURE_RESOURCE_GROUP="<resource group>"
 
 # 예: koreacentral (한국 중부)
-$ export REGION="koreacentral"
-$ export RESOURCE_GROUP="cb-ladybugRG"
+$ export AZURE_REGION="koreacentral"
+$ export AZURE_RESOURCE_GROUP="cb-ladybugRG"
 ```
 
 * Cloud Connection Info. 등록
@@ -120,12 +120,12 @@ $ ./connectioninfo-create.sh AZURE
 
 ```
 # AWS/GCP
-$ export REGION="<region name>"
-$ export ZONE="<zone name>"
+$ export [AWS/GCP]_REGION="<region name>"
+$ export [AWS/GCP]_ZONE="<zone name>"
 
 # AZURE
-$ export REGION="<region name>"
-$ export RESOURCE_GROUP="<resource group>"
+$ export AZURE_REGION="<region name>"
+$ export AZURE_RESOURCE_GROUP="<resource group>"
 
 $ ./connectioninfo-create.sh [AWS/GCP/AZURE] add
 ```

--- a/docs/test/batch-register-cloud-info.sh.example
+++ b/docs/test/batch-register-cloud-info.sh.example
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# GCP
+export GCP_PROJECT="your-gcp-project-id"
+export GCP_PKEY="-----BEGIN PRIVATE KEY-----\nyour-key=\n-----END PRIVATE KEY-----\n"
+export GCP_SA="1111-compute@developer.gserviceaccount.com"
+
+export GCP_REGION="asia-northeast3"
+export GCP_ZONE="asia-northeast3-a"
+
+./connectioninfo-create.sh GCP
+
+
+
+# AWS
+export AWS_KEY="xxxxxxxx"
+export AWS_SECRET="yyyyyyyy/zzzzzzzz"
+
+export AWS_REGION="ap-northeast-1"
+export AWS_ZONE="ap-northeast-1a"
+
+./connectioninfo-create.sh AWS
+
+
+
+# Azure
+export AZURE_CLIENT_ID="uuid"
+export AZURE_CLIENT_SECRET="uuid"
+export AZURE_TENANT_ID="uuid"
+export AZURE_SUBSCRIPTION_ID="uuid"
+
+export AZURE_REGION="japaneast" 
+export AZURE_RESOURCE_GROUP="ladybug-test"
+
+./connectioninfo-create.sh AZURE

--- a/docs/test/connectioninfo-create.sh
+++ b/docs/test/connectioninfo-create.sh
@@ -49,106 +49,145 @@ if [ "${v_OPTION}" != "add" ]; then
 	if [ "${v_CSP}" == "GCP" ]; then 
 
 		# Project
-		v_GCP_PROJECT="${PROJECT}"
+		v_GCP_PROJECT="${GCP_PROJECT}"
 		if [ "${v_GCP_PROJECT}" == "" ]; then 
 			read -e -p "Project ? [예:kore3-etri-cloudbarista] : "  v_GCP_PROJECT
 			if [ "${v_GCP_PROJECT}" == "" ]; then echo "[ERROR] missing gcp <project_id>"; exit -1;fi
 		fi
 
 		# private key
-		v_GCP_PKEY="${PKEY}"
+		v_GCP_PKEY="${GCP_PKEY}"
 		if [ "${v_GCP_PKEY}" == "" ]; then 
 			read -e -p "Private Key ? [예:-----BEGIN PRIVATE KEY-----\n....] : "  v_GCP_PKEY
 			if [ "${v_GCP_PKEY}" == "" ]; then echo "[ERROR] missing gcp <private_key>"; exit -1;fi
 		fi
 
 		# system account
-		v_GCP_SA="${SA}"
+		v_GCP_SA="${GCP_SA}"
 		if [ "${v_GCP_SA}" == "" ]; then 
 			read -e -p "Service account (client email) ? [예:331829771895-compute@developer.gserviceaccount.com] : "  v_GCP_SA
 			if [ "${v_GCP_SA}" == "" ]; then echo "[ERROR] missing gcp <client_email>"; exit -1;fi
 		fi
 
+		# region
+		v_REGION="${GCP_REGION}"
+		if [ "${v_REGION}" == "" ]; then 
+			read -e -p "region ? [예:asia-northeast3] : "  v_REGION
+			if [ "${v_REGION}" == "" ]; then echo "[ERROR] missing region"; exit -1;fi
+		fi
+
+		# zone
+		v_ZONE="${GCP_ZONE}"
+		if [ "${v_ZONE}" == "" ]; then 
+			read -e -p "zone ? [예:asia-northeast3-a] : "  v_ZONE
+			if [ "${v_ZONE}" == "" ]; then v_ZONE="${v_REGION}-a";fi
+		fi
 	fi
 
 	# AWS
 	if [ "${v_CSP}" == "AWS" ]; then 
 
-		v_AWS_ACCESS_KEY="${KEY}"
+		v_AWS_ACCESS_KEY="${AWS_KEY}"
 		if [ "${v_AWS_ACCESS_KEY}" == "" ]; then 
 			read -e -p "Access Key ? [예:AH24UUA2ZGNOP6DKKIA6] : "  v_AWS_ACCESS_KEY
 			if [ "${v_AWS_ACCESS_KEY}" == "" ]; then echo "[ERROR] missing <aws_access_key_id>"; exit -1;fi
 		fi
 
-		v_AWS_SECRET="${SECRET}"
+		v_AWS_SECRET="${AWS_SECRET}"
 		if [ "${v_AWS_SECRET}" == "" ]; then 
 			read -e -p "Access-key Secret ? [예:y76ZWz6A/vwqGanDAI926TTPCJrrMo1VbPOh8X7K] : "  v_AWS_SECRET
 			if [ "${v_AWS_SECRET}" == "" ]; then echo "[ERROR] missing <aws_secret_access_key>"; exit -1;fi
 		fi
 
+		# region
+		v_REGION="${AWS_REGION}"
+		if [ "${v_REGION}" == "" ]; then 
+			read -e -p "region ? [예:asia-northeast3] : "  v_REGION
+			if [ "${v_REGION}" == "" ]; then echo "[ERROR] missing region"; exit -1;fi
+		fi
+
+		# zone
+		v_ZONE="${AWS_ZONE}"
+		if [ "${v_ZONE}" == "" ]; then 
+			read -e -p "zone ? [예:asia-northeast3-a] : "  v_ZONE
+			if [ "${v_ZONE}" == "" ]; then v_ZONE="${v_REGION}-a";fi
+		fi
 	fi
 
 	# AZURE
 	if [ "${v_CSP}" == "AZURE" ]; then 
 
 		# client id
-		v_AZURE_CLIENT_ID="${CLIENT_ID}"
+		v_AZURE_CLIENT_ID="${AZURE_CLIENT_ID}"
 		if [ "${v_AZURE_CLIENT_ID}" == "" ]; then 
 			read -e -p "client id ? [예:123445-dfef-s9df-9292-c9d9d01030] : "  v_AZURE_CLIENT_ID
 			if [ "${v_AZURE_CLIENT_ID}" == "" ]; then echo "[ERROR] missing <azure_client_id>"; exit -1;fi
 		fi	
 
 		# client secret
-		v_AZURE_CLIENT_SECRET="${CLIENT_SECRET}"
+		v_AZURE_CLIENT_SECRET="${AZURE_CLIENT_SECRET}"
 		if [ "${v_AZURE_CLIENT_SECRET}" == "" ]; then 
 			read -e -p "client secret ? [예:239DLKJFSJ=DFLKJSFK-FDSLKJFS0d] : "  v_AZURE_CLIENT_SECRET
 			if [ "${v_AZURE_CLIENT_SECRET}" == "" ]; then echo "[ERROR] missing <azure_client_secret>"; exit -1;fi
 		fi	
 
 		# tenant id
-		v_AZURE_TENANT_ID="${TENANT_ID}"
+		v_AZURE_TENANT_ID="${AZURE_TENANT_ID}"
 		if [ "${v_AZURE_TENANT_ID}" == "" ]; then 
 			read -e -p "tenant id ? [예:123445-dfef-s9df-9292-c9d9d01030] : "  v_AZURE_TENANT_ID
 			if [ "${v_AZURE_TENANT_ID}" == "" ]; then echo "[ERROR] missing <azure_tenant_id>"; exit -1;fi
 		fi	
 
 		# subscription id
-		v_AZURE_SUBSCRIPTION_ID="${SUBSCRIPTION_ID}"
+		v_AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID}"
 		if [ "${v_AZURE_SUBSCRIPTION_ID}" == "" ]; then 
 			read -e -p "subscription id ? [예:123445-dfef-s9df-9292-c9d9d01030] : "  v_AZURE_SUBSCRIPTION_ID
 			if [ "${v_AZURE_SUBSCRIPTION_ID}" == "" ]; then echo "[ERROR] missing <azure_subscription_id>"; exit -1;fi
 		fi	
 
+		# region
+		v_REGION="${AZURE_REGION}"
+		if [ "${v_REGION}" == "" ]; then 
+			read -e -p "region ? [예:asia-northeast3] : "  v_REGION
+			if [ "${v_REGION}" == "" ]; then echo "[ERROR] missing region"; exit -1;fi
+		fi
+
+		# resource group
+		v_RESOURCE_GROUP="${AZURE_RESOURCE_GROUP}"
+		if [ "${v_RESOURCE_GROUP}" == "" ]; then 
+			read -e -p "resource group ? [예:cb-ladybugRG] : "  v_RESOURCE_GROUP
+			if [ "${v_RESOURCE_GROUP}" == "" ]; then echo "[ERROR] missing resource group"; exit -1;fi
+		fi
 	fi
 
 fi
 
-# region
-v_REGION="${REGION}"
-if [ "${v_REGION}" == "" ]; then 
-	read -e -p "region ? [예:asia-northeast3] : "  v_REGION
-	if [ "${v_REGION}" == "" ]; then echo "[ERROR] missing region"; exit -1;fi
-fi
+# # region
+# v_REGION="${REGION}"
+# if [ "${v_REGION}" == "" ]; then 
+# 	read -e -p "region ? [예:asia-northeast3] : "  v_REGION
+# 	if [ "${v_REGION}" == "" ]; then echo "[ERROR] missing region"; exit -1;fi
+# fi
 
-if [ "${v_CSP}" == "AZURE" ]; then 
+# if [ "${v_CSP}" == "AZURE" ]; then 
 
-	# resource group
-	v_RESOURCE_GROUP="${RESOURCE_GROUP}"
-	if [ "${v_RESOURCE_GROUP}" == "" ]; then 
-		read -e -p "resource group ? [예:cb-ladybugRG] : "  v_RESOURCE_GROUP
-		if [ "${v_RESOURCE_GROUP}" == "" ]; then echo "[ERROR] missing resource group"; exit -1;fi
-	fi
+# 	# resource group
+# 	v_RESOURCE_GROUP="${RESOURCE_GROUP}"
+# 	if [ "${v_RESOURCE_GROUP}" == "" ]; then 
+# 		read -e -p "resource group ? [예:cb-ladybugRG] : "  v_RESOURCE_GROUP
+# 		if [ "${v_RESOURCE_GROUP}" == "" ]; then echo "[ERROR] missing resource group"; exit -1;fi
+# 	fi
 
-else
+# else
 
-	# zone
-	v_ZONE="${ZONE}"
-	if [ "${v_ZONE}" == "" ]; then 
-		read -e -p "zone ? [예:asia-northeast3-a] : "  v_ZONE
-		if [ "${v_ZONE}" == "" ]; then v_ZONE="${v_REGION}-a";fi
-	fi
+# 	# zone
+# 	v_ZONE="${ZONE}"
+# 	if [ "${v_ZONE}" == "" ]; then 
+# 		read -e -p "zone ? [예:asia-northeast3-a] : "  v_ZONE
+# 		if [ "${v_ZONE}" == "" ]; then v_ZONE="${v_REGION}-a";fi
+# 	fi
 
-fi
+# fi
 
 NM_CREDENTIAL="credential-${v_CSP_LOWER}"
 NM_REGION="region-${v_CSP_LOWER}-${v_REGION}"

--- a/docs/test/env.sh
+++ b/docs/test/env.sh
@@ -29,17 +29,17 @@ if [ "${v_FILE}" = "" ]; then echo "[ERROR] missing <credential file>"; exit -1;
 # credential (gcp)
 if [ "${v_CSP}" = "GCP" ]; then
 
-	export PROJECT=$(cat ${v_FILE} | jq -r ".project_id")
-	export PKEY=$(cat ${v_FILE} | jq -r ".private_key" | while read line; do	if [ "$line" != "" ]; then	echo -n "$line\n";	fi; done )
-	export SA=$(cat ${v_FILE} | jq -r ".client_email")
+	export GCP_PROJECT=$(cat ${v_FILE} | jq -r ".project_id")
+	export GCP_PKEY=$(cat ${v_FILE} | jq -r ".private_key" | while read line; do	if [ "$line" != "" ]; then	echo -n "$line\n";	fi; done )
+	export GCP_SA=$(cat ${v_FILE} | jq -r ".client_email")
 
 fi
 
 # credential (aws)
 if [ "${v_CSP}" = "AWS" ]; then
 
-	export KEY="$(head -n 2 ${v_FILE} | tail -n 1 | sed  '/^$/d; s/\r//; s/aws_access_key_id = //g')"
-	export SECRET="$(head -n 3 ${v_FILE} | tail -n 1 | sed  '/^$/d; s/\r//; s/aws_secret_access_key = //g')"
+	export AWS_KEY="$(head -n 2 ${v_FILE} | tail -n 1 | sed  '/^$/d; s/\r//; s/aws_access_key_id = //g')"
+	export AWS_SECRET="$(head -n 3 ${v_FILE} | tail -n 1 | sed  '/^$/d; s/\r//; s/aws_secret_access_key = //g')"
 
 fi
 
@@ -49,9 +49,9 @@ fi
 echo ""
 echo "[Env.]"
 echo "GCP"
-echo "- PROJECT is '${PROJECT}'"
-echo "- PKEY    is '${PKEY}'"
-echo "- SA      is '${SA}'"
+echo "- PROJECT is '${GCP_PROJECT}'"
+echo "- PKEY    is '${GCP_PKEY}'"
+echo "- SA      is '${GCP_SA}'"
 echo "AWS"
-echo "- KEY     is '${KEY}'"
-echo "- SECRET  is '${SECRET}'"
+echo "- KEY     is '${AWS_KEY}'"
+echo "- SECRET  is '${AWS_SECRET}'"


### PR DESCRIPTION
Related issue: #74

> 예를 들어, https://github.com/cloud-barista/cb-ladybug/tree/master/docs/test#cloud-connection-info-%EB%93%B1%EB%A1%9D 에서
> `REGION`, `ZONE` 등의 환경변수를 계속 재활용하여 사용하고 있어서
> - GCP 등록할 때, AWS 등록할 때, Azure 등록할 때 매번 업데이트 해 주어야 합니다.
> - 실행 순서에 유의해야 합니다.
> 
> 이를
> GCP 관련 env var 에는 `GCP_` 라는 prefix 를 붙이는 식으로 CSP 별로 구분하고
> 파일로 만든 다음 (예: `cloud-connection-info.env`)
> 사용자가 이 파일을 업데이트하도록 하고
> `./connectioninfo-create.sh` 파일 실행 시 `cloud-connection-info.env` 에 있는 환경변수를 읽도록 하는
> 방안이 있을 수 있습니다.
