### PR TITLE
test: extraction from google credential(json) in zsh

### DIFF
--- a/docs/test/env.sh
+++ b/docs/test/env.sh
@@ -29,9 +29,9 @@ if [ "${v_FILE}" = "" ]; then echo "[ERROR] missing <credential file>"; exit -1;
 # credential (gcp)
 if [ "${v_CSP}" = "GCP" ]; then
 
-	export GCP_PROJECT=$(cat ${v_FILE} | jq -r ".project_id")
-	export GCP_PKEY=$(cat ${v_FILE} | jq -r ".private_key" | while read line; do	if [ "$line" != "" ]; then	echo -n "$line\n";	fi; done )
-	export GCP_SA=$(cat ${v_FILE} | jq -r ".client_email")
+	export GCP_PROJECT=$(cat ${v_FILE} | jq ".project_id" | tr -d '"')
+	export GCP_PKEY=$(cat ${v_FILE} | jq ".private_key" | tr -d '"')
+	export GCP_SA=$(cat ${v_FILE} | jq ".client_email" | tr -d '"')
 
 fi
 
@@ -67,17 +67,17 @@ fi
 echo ""
 echo "[Env.]"
 echo "GCP"
-echo "- PROJECT is '${GCP_PROJECT}'"
-echo "- PKEY    is '${GCP_PKEY}'"
-echo "- SA      is '${GCP_SA}'"
+echo -E "- PROJECT is '${GCP_PROJECT}'"
+echo -E "- PKEY    is '${GCP_PKEY}'"
+echo -E "- SA      is '${GCP_SA}'"
 echo "AWS"
-echo "- KEY     is '${AWS_KEY}'"
-echo "- SECRET  is '${AWS_SECRET}'"
+echo -E "- KEY     is '${AWS_KEY}'"
+echo -E "- SECRET  is '${AWS_SECRET}'"
 echo "AZURE"
-echo "- CLIENT_ID       is '${AZURE_CLIENT_ID}'"
-echo "- CLIENT_SECRET   is '${AZURE_CLIENT_SECRET}'"
-echo "- TENANT_ID       is '${AZURE_TENANT_ID}'"
-echo "- SUBSCRIPTION_ID is '${AZURE_SUBSCRIPTION_ID}'"
+echo -E "- CLIENT_ID       is '${AZURE_CLIENT_ID}'"
+echo -E "- CLIENT_SECRET   is '${AZURE_CLIENT_SECRET}'"
+echo -E "- TENANT_ID       is '${AZURE_TENANT_ID}'"
+echo -E "- SUBSCRIPTION_ID is '${AZURE_SUBSCRIPTION_ID}'"
 echo "ALIBABA"
-echo "- KEY     is '${ALIBABA_KEY}'"
-echo "- SECRET  is '${ALIBABA_SECRET}'"
+echo -E "- KEY     is '${ALIBABA_KEY}'"
+echo -E "- SECRET  is '${ALIBABA_SECRET}'"


### PR DESCRIPTION
zsh 환경에서 source env.sh <google-credential.json>를 실행하면 GCP에 로그인이 되지 않아 아래의 에러가 발생합니다.

```
ERRO[0910] Cannot do ssh, VM IP is not Running (name=cluster-01-w-2-ez4j4, ip=Not assigned yet, systemMessage={"message":"Post \"https://compute.googleapis.com/compute/v1/projects/sykim-etri-324002/zones/asia-
northeast3-a/instances?alt=json\u0026prettyPrint=false\": private key should be a PEM or plain PKCS1 or PKCS8; parse error: asn1: structure error: tags don't match (16 vs {class:0 tag:13 length:45 isCompound:t
rue}) {optional:false explicit:false application:false private:false defaultValue:\u003cnil\u003e tag:\u003cnil\u003e stringType:0 timeType:0 set:false omitEmpty:false} pkcs1PrivateKey @2"}
)
```

원인 파악 결과 env.sh에서 jq의 -r 옵션으로 인해 .private_key에 포함된 escape character(\n)의 값에 왜곡된 것 같습니다.(추정)
그래서 -r 옵션을 없애고 이로 인해 문자열의 앞뒤에 생기는 "(double quotes)를 tr -d로 제거하도록 수정하였습니다.

bash와 zsh에서 테스트하여 정상 동작을 확인하였습니다.